### PR TITLE
Backend dotenv dependencies migration

### DIFF
--- a/backend/account_management/.env.vault
+++ b/backend/account_management/.env.vault
@@ -1,0 +1,25 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="MSaSLgxwdIPkIJGsjA6ktFUYbtUSgDiAIE0VF6BnitfZl1mv3jnvxd3fQVvkCi1VUK2IFDJg0RfpvA+1mya2vgKTaJnyoMaEfVak+P96B152pbW8wLG4Cmt5t90unmwVqAG1asF5JWahofQgeMCc9QFBTNl9mREJ"
+DOTENV_VAULT_DEVELOPMENT_VERSION=2
+
+# ci
+DOTENV_VAULT_CI="0wtQpbLGQg5jUK83uAmFg8bedl75HHf2D6LtLHD7rv+tVUupShEMvaybUApw54jzZccjl8IYm3yNtfBVtlPnYMRwjK9RYWA7R/3d3AIxmYetkwRbsrVO43c/wn8/XrDRETU4M3iDw4CxVqrzIg/GMeusLprlzdc4Ryc="
+DOTENV_VAULT_CI_VERSION=3
+
+# staging
+DOTENV_VAULT_STAGING="R9cKiEu/UMne2AdoFZrNmsw1f6Lx03tL1FVJCTb81bGhvNYCYqLIaYQskOr2q4+xy5U4"
+DOTENV_VAULT_STAGING_VERSION=2
+
+# production
+DOTENV_VAULT_PRODUCTION="7TMUIQxtiDecYv4NM9VjROg2Ya9hHCcnw74X0eCOVLsQktV3O1WkB2SDXHaUdziDNUBa"
+DOTENV_VAULT_PRODUCTION_VERSION=2
+
+#/----------------settings/metadata-----------------/
+DOTENV_VAULT="vlt_84f4399cfb374e8727e44184a5192206905742dc429c3fde19278e06b956b341"
+DOTENV_API_URL="https://vault.dotenv.org"
+DOTENV_CLI="npx dotenv-vault@latest"

--- a/backend/account_management/.gitignore
+++ b/backend/account_management/.gitignore
@@ -31,3 +31,8 @@ go.work
 
 ## air tool
 tmp
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault

--- a/backend/account_management/go.mod
+++ b/backend/account_management/go.mod
@@ -4,15 +4,17 @@ go 1.21.3
 
 require (
 	github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
+	github.com/dotenv-org/godotenvvault v0.6.0
+	github.com/gofiber/fiber/v2 v2.50.0
 	go.mongodb.org/mongo-driver v1.13.0
+	golang.org/x/crypto v0.7.0
 )
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
-	github.com/gofiber/fiber/v2 v2.50.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.3.1 // indirect
-	github.com/joho/godotenv v1.5.1
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/klauspost/compress v1.16.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
@@ -26,7 +28,6 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20181117223130-1be2e3e5546d // indirect
-	golang.org/x/crypto v0.7.0 // indirect
 	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
 	golang.org/x/sys v0.13.0 // indirect
 	golang.org/x/text v0.8.0 // indirect

--- a/backend/account_management/go.sum
+++ b/backend/account_management/go.sum
@@ -1,12 +1,16 @@
 github.com/andybalholm/brotli v1.0.5 h1:8uQZIdzKmjc/iuPu7O2ioW48L81FgatrcpfFmiq/cCs=
 github.com/andybalholm/brotli v1.0.5/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1 h1:CaO/zOnF8VvUfEbhRatPcwKVWamvbYd8tQGRWacE9kU=
 github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1/go.mod h1:+hnT3ywWDTAFrW5aE+u2Sa/wT555ZqwoCS+pk3p6ry4=
+github.com/dotenv-org/godotenvvault v0.6.0 h1:e6rUPELZaPmf6SgxxdB3nACG9VQAE8+omrSSZm0QUgk=
+github.com/dotenv-org/godotenvvault v0.6.0/go.mod h1:q/635WfmO04uUBVwrDWchRPOvPWaplWC6Udm+illcS4=
 github.com/gofiber/fiber/v2 v2.50.0 h1:ia0JaB+uw3GpNSCR5nvC5dsaxXjRU5OEu36aytx+zGw=
 github.com/gofiber/fiber/v2 v2.50.0/go.mod h1:21eytvay9Is7S6z+OgPi7c7n4++tnClWmhpimVHMimw=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
 github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -80,4 +84,5 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/backend/account_management/main.go
+++ b/backend/account_management/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
-	"github.com/joho/godotenv"
+	"github.com/dotenv-org/godotenvvault"
 )
 
 func main() {
@@ -26,8 +26,9 @@ func main() {
 }
 
 func uploadEnv() {
-	err := godotenv.Load()
+	err := godotenvvault.Load()
 	if err != nil {
 		log.Fatal("Error loading .env file")
+// application should panic 
 	}
 }

--- a/backend/product_management/.env.vault
+++ b/backend/product_management/.env.vault
@@ -1,0 +1,25 @@
+#/-------------------.env.vault---------------------/
+#/         cloud-agnostic vaulting standard         /
+#/   [how it works](https://dotenv.org/env-vault)   /
+#/--------------------------------------------------/
+
+# development
+DOTENV_VAULT_DEVELOPMENT="xEA9keEO40B9mEIL2c84JyRY63TiOPVJIC9u1glYR19nE8L6/r31dnIA97nigrt4K9Dg/T7/1e1HIvmLDeyYjSTBKVnWZiTLvJ3kCsn5NPkf+urAjyUgdfxoxtgJmiiBbtwysoCgSJAiXbfMR551gXvqkZVPVcvPzT4NJ1YYSzclJ4rXHbHc7Iemx9t34Qf6feYQqQl5km+lOdQY1EpYFgVZ9EWTg/gyML8IaVVXamf0dTOyni3G2hdSWTDaUki86+vuqBglyrlsWoZ2FCsa6dmCYhfL6a60ocgsDhIHBccFt0IcayUPPV2IgmCjaqXKF4yiLcLegiARqpoEkcdzk2efpdyy72klwZZO4Q=="
+DOTENV_VAULT_DEVELOPMENT_VERSION=4
+
+# ci
+DOTENV_VAULT_CI="USIfUUuyWENZXBa9mAtUPKfP/D3o7wR9DtRT0b1eQ+xqjpQYQlYsShBXalmriFuzX0hh3+BBo2b7LVNLxSRgWl6lBoAIjT+DOp6Qk9IFVUBH+YGlx5GM7nySf0rCxqlShMAGyksvchzrMnfrPGEHSJmTNLtd6Z+BMb3A+KXI8rLhTT1w47zB2iSNkaILYE9s70JDfVuWpXzFBPS941T0vSg9txgsc5l/+SSASKEEqB/qB1P0bBHm/dD3nGyPRHIboMqMUFe4hXX7VEWBcnrrTyPG0oIuAbEu9d0YhXEBD9qki4CwY2L7LPE7QUCIvP1JumSBAsi1aBboi1lDFZAOinlDnZPkgQ=="
+DOTENV_VAULT_CI_VERSION=3
+
+# staging
+DOTENV_VAULT_STAGING="PwU/3ruaMKWGt1+TJv1LwEjz6f1tohWJC6/3/uMvUG9VglymWkQrWS6J1Surbhf/+w7KUUyewgALoCvMSn/PdUNgT0gMp3Th3uUcjPiPBmtbSzcybs2nySU3BFSBXenEAEnzl2r96EB+L/GYCx74vzirAAM="
+DOTENV_VAULT_STAGING_VERSION=2
+
+# production
+DOTENV_VAULT_PRODUCTION="VJCKJHxELcx9zcCiSvDa484BzJ1Z8ZfnRAUjLHtCE2n4Z44MxSRAN2OJima68knOL/ETQrZ9ts1WzRREgoSEkQbkMy/xxVD5FGY7UPszxlVMRmTayYlqR2AJztWpOYyyQRgtGKpDPT7MHJtjKLdKlB5Ro5XbA8nS+SmmBx6lP5f8rfiEHDnr0hwEihhYWp1pRWWNEtX0yP8/auS1qroaDihIjRauNTOGuIoIhuPA2o7NO0fbfLxqmMdTur77rOlCfKgxHin5H1CbLISpn8H6TLa0bZ4pQuCXWfgtBucXxaEUKNXFrgusdN9gK+dCz5ubvPyc9R9gCBDPaDT6EmYoHmp6Lp8npvjwjqS4pA=="
+DOTENV_VAULT_PRODUCTION_VERSION=3
+
+#/----------------settings/metadata-----------------/
+DOTENV_VAULT="vlt_7d645ae653bc2a63c2183aa10bc2c7a3fb23bddd7c132560f06e592f0859becc"
+DOTENV_API_URL="https://vault.dotenv.org"
+DOTENV_CLI="npx dotenv-vault@latest"

--- a/backend/product_management/.gitignore
+++ b/backend/product_management/.gitignore
@@ -31,3 +31,8 @@ go.work
 
 ## air tool
 tmp
+
+.env*
+.flaskenv*
+!.env.project
+!.env.vault

--- a/backend/product_management/app/go.mod
+++ b/backend/product_management/app/go.mod
@@ -1,1 +1,7 @@
 module product_management/app
+
+go 1.21.4
+
+require (
+	github.com/dotenv-org/godotenvvault v0.6.0 // indirect
+)

--- a/backend/product_management/app/utils/Godotenv.go
+++ b/backend/product_management/app/utils/Godotenv.go
@@ -1,9 +1,11 @@
 package utils
 
-import "github.com/joho/godotenv"
+import "github.com/dotenv-org/godotenvvault"
 
 func LoadGodotenv() {
-	if err := godotenv.Load(); err != nil {
+	if err := godotenvvault.Load(); 
+	err != nil {
 		panic(err)
 	}
 }
+

--- a/backend/product_management/go.mod
+++ b/backend/product_management/go.mod
@@ -1,11 +1,12 @@
 module antwood_team/product_management
 
-go 1.18
+go 1.21.3
 
 require (
 	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/cloudinary/cloudinary-go v1.7.0 // indirect
 	github.com/creasty/defaults v1.5.1 // indirect
+	github.com/dotenv-org/godotenvvault v0.6.0 // indirect
 	github.com/gofiber/fiber/v2 v2.50.0 // indirect
 	github.com/golang/snappy v0.0.1 // indirect
 	github.com/google/uuid v1.3.1 // indirect

--- a/backend/product_management/go.work
+++ b/backend/product_management/go.work
@@ -1,9 +1,9 @@
-go 1.21.3
+go 1.21.4
 
-use(
-./app
-./context
-./router
-.
-./test
+use (
+	.
+	./app
+	./context
+	./router
+	./test
 )


### PR DESCRIPTION
## What did I do?
Migrated dependencies of the backend from joho/godotenv to dotenv-org/godotenvvault.

## How did I do?
- Updated the code of the files that load dotenv variables to the program to use the new dependency.
- Updated the go.mod to reflect the dependency change.

## Why did I do it?
joho/godotenv does not provide security to handle .env and dotenv-org/godotenvvault does.

Please read this guide to be able to run our backend microservices: https://www.dotenv.org/docs

---
#8686cvj44[code review]
