### PR TITLE
Fixed [BUG-37]

### DIFF
--- a/frontend/src/components/auth/GoogleSignInButton.jsx
+++ b/frontend/src/components/auth/GoogleSignInButton.jsx
@@ -40,8 +40,8 @@ export default function GoogleSignInButton({hasAccount}) {
                     onError={(err) => {
                         console.error('Failed to obtain the credential', err);
                     }}
-                />;
-            </GoogleOAuthProvider>;
+                />
+            </GoogleOAuthProvider>
 
         </div>
     );


### PR DESCRIPTION
[BUG - 37] When you exit and enter the registration form several times, the google option disappears.

### Description
When I go in and out several times from the user icon where is to register or log in, the first time if I can see the gmail option, but then disappears this option.
